### PR TITLE
Attempt to update Google Analytics due to deprecation of Google UA

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Reaction Mechanism Generator
+Copyright (c) 2024 Reaction Mechanism Generator
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -133,15 +133,14 @@
     </footer>
 </div>
 
-<script type="text/javascript">
-    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-    try {
-        var pageTracker = _gat._getTracker("UA-24556433-3");
-        pageTracker._trackPageview();
-    } catch (err) {}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TBF6RF8547"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TBF6RF8547');
 </script>
 
 


### PR DESCRIPTION
See https://github.com/ReactionMechanismGenerator/RMG-website/pull/269.

This website used Google Universal Analytics to track and understand user behavior. Universal Analytics (UA) stopped working on 2023/07/01. This PR is an attempt to update to GA4 following the template provided here: https://support.google.com/analytics/answer/10271001?hl=en#zippy=%2Cin-this-article